### PR TITLE
Fixed issue with only returning 1 value from request. Removed "ky" dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const ky = require("ky-universal");
 const isUUID = require("is-uuid");
 
 class HypixelError extends Error {
@@ -15,10 +14,16 @@ module.exports = async (endpoint, options = {}) => {
 		throw new TypeError("`options.key` must be set to an API key!");
 	}
 
-	const request = await ky(endpoint, {
-		prefixUrl: "https://api.hypixel.net",
-		searchParams: options,
+	let url = `https://api.hypixel.net/${endpoint}`;
+	Object.keys(options).forEach(key => {
+		if (key == "key") {
+			url += `&key=${encodeURIComponent(options[key])}`;
+		} else {
+			url += `?${key}=${encodeURIComponent(options[key])}`;
+		}
 	});
+	const request = await fetch(url);
+
 	const data = await request.json();
 
 	if (!data.success) {
@@ -26,7 +31,6 @@ module.exports = async (endpoint, options = {}) => {
 	}
 
 	return data;
-	// return Object.values(data)[1]
 };
 
 module.exports.HypixelError = HypixelError;

--- a/index.js
+++ b/index.js
@@ -15,14 +15,15 @@ module.exports = async (endpoint, options = {}) => {
 	}
 
 	let url = `https://api.hypixel.net/${endpoint}`;
-	Object.keys(options).forEach(key => {
-		if (key == "key") {
-			url += `&key=${encodeURIComponent(options[key])}`;
-		} else {
-			url += `?${key}=${encodeURIComponent(options[key])}`;
-		}
+	Object.keys(options).forEach((key) => {
+		if (key == "key") return;
+		url += `?${key}=${encodeURIComponent(options[key])}`;
 	});
-	const request = await fetch(url);
+	const request = await fetch(url, {
+		headers: {
+			"API-KEY": options.key,
+		},
+	});
 
 	const data = await request.json();
 

--- a/index.js
+++ b/index.js
@@ -1,31 +1,32 @@
-"use strict"
+"use strict";
 
-const ky = require("ky-universal")
-const isUUID = require("is-uuid")
+const ky = require("ky-universal");
+const isUUID = require("is-uuid");
 
 class HypixelError extends Error {
 	constructor(message = "", ...args) {
-		super(message, ...args)
-		this.message = message
+		super(message, ...args);
+		this.message = message;
 	}
 }
 
 module.exports = async (endpoint, options = {}) => {
 	if (!isUUID.v4(options.key)) {
-		throw new TypeError("`options.key` must be set to an API key!")
+		throw new TypeError("`options.key` must be set to an API key!");
 	}
 
 	const request = await ky(endpoint, {
 		prefixUrl: "https://api.hypixel.net",
-		searchParams: options
-	})
-	const data = await request.json()
+		searchParams: options,
+	});
+	const data = await request.json();
 
 	if (!data.success) {
-		throw new HypixelError(data.cause)
+		throw new HypixelError(data.cause);
 	}
 
-	return Object.values(data)[1]
-}
+	return data;
+	// return Object.values(data)[1]
+};
 
-module.exports.HypixelError = HypixelError
+module.exports.HypixelError = HypixelError;

--- a/package.json
+++ b/package.json
@@ -27,9 +27,7 @@
 		"interface"
 	],
 	"dependencies": {
-		"is-uuid": "^1.0.2",
-		"ky": "^0.19.0",
-		"ky-universal": "^0.5.0"
+		"is-uuid": "^1.0.2"
 	},
 	"devDependencies": {
 		"ava": "^3.5.2",

--- a/test.js
+++ b/test.js
@@ -1,14 +1,20 @@
-const test = require("ava")
-const hypixie = require(".")
+const test = require("ava");
+const hypixie = require(".");
 
-test("main", async t => {
+test("main", async (t) => {
 	if (!process.env.HYPIXEL_KEY) {
-		console.warn("Set the HYPIXEL_KEY environment variable in order to test.")
-		return t.pass()
+		console.warn("Set the HYPIXEL_KEY environment variable in order to test.");
+		return t.pass();
 	}
 
-	const key = process.env.HYPIXEL_KEY
+	const key = process.env.HYPIXEL_KEY;
 
-	const { displayname } = await hypixie("player", { uuid: "56da43a4-088d-4a76-82b6-dd431535015e", key })
-	t.is(displayname, "Richienb")
-})
+	const response = await hypixie("player", {
+		uuid: "56da43a4-088d-4a76-82b6-dd431535015e",
+		key,
+	});
+	console.log(response);
+
+	// const { displayname } = await hypixie("player", { uuid: "56da43a4-088d-4a76-82b6-dd431535015e", key })
+	// t.is(displayname, "Richienb")
+});

--- a/test.js
+++ b/test.js
@@ -1,20 +1,17 @@
-const test = require("ava");
+const key = process.env.HYPIXEL_KEY;
 const hypixie = require(".");
+const test = require("ava");
 
-test("main", async (t) => {
+test("main", async t => {
 	if (!process.env.HYPIXEL_KEY) {
 		console.warn("Set the HYPIXEL_KEY environment variable in order to test.");
 		return t.pass();
 	}
 
-	const key = process.env.HYPIXEL_KEY;
-
 	const response = await hypixie("player", {
 		uuid: "56da43a4-088d-4a76-82b6-dd431535015e",
-		key,
+		key
 	});
-	console.log(response);
-
-	// const { displayname } = await hypixie("player", { uuid: "56da43a4-088d-4a76-82b6-dd431535015e", key })
-	// t.is(displayname, "Richienb")
+	const { displayname } = response.player;
+	t.is(displayname, "Richienb");
 });


### PR DESCRIPTION
Fixed issue on line 28 in "index.js" where you only return 1 value instead of full response this leads to an issue where if you have a request with multiple values example `skyblock/bazaar`
https://api.hypixel.net/#tag/SkyBlock/paths/~1v2~1skyblock~1bazaar/get
the successful respond contains 3 values:
- success: boolean
- lastUpdated: i64
- products: object
the issue in the code is that you only get 1 value in the response "lastUpdated" in the new code i return the whole request I also changed the test case to work for the new changes
```js
...
const data = await request.json()
...
return Object.values(data)[1]
```
Also removed unecessary dependency "ky" since the dependency count went from like 2,000 to ~700. I think you can just go down to using only "is-uuid" depedency since for test cases you can just use asser_eqs and i dont really know what "xo" is for.
I dont think this pr will get merged but i hope so